### PR TITLE
feat(date): show google calendar events

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -153,6 +153,9 @@ function startDevServer() {
     loader: {
       '.yml': 'text',
     },
+    define: {
+      'process.env.GCAL_CLIENT_ID': JSON.stringify(process.env.GCAL_CLIENT_ID || ''),
+    },
     plugins: [
       CssModulesPlugin({
         localsConvention: 'camelCase',

--- a/src/ui/globals.d.ts
+++ b/src/ui/globals.d.ts
@@ -30,4 +30,5 @@ interface Window {
     invoke: any;
   };
   __SLU_WIDGET: import('@seelen-ui/lib/types').Widget;
+  google?: any;
 }

--- a/src/ui/toolbar/modules/Date/Calendar.tsx
+++ b/src/ui/toolbar/modules/Date/Calendar.tsx
@@ -93,6 +93,47 @@ function DateCalendar() {
 
   const [date, setDate] = useState(moment().locale(i18n.language));
   const [viewMode, setViewMode] = useState<CalendarMode | undefined>('month');
+  const [events, setEvents] = useState<Record<string, any[]>>({});
+
+  useEffect(() => {
+    const token = localStorage.getItem('gcal_token');
+    if (!token) {
+      setEvents({});
+      return;
+    }
+
+    async function fetchEvents() {
+      try {
+        const timeMin = date.clone().startOf('month').startOf('day').toISOString();
+        const timeMax = date.clone().endOf('month').endOf('day').toISOString();
+        const res = await fetch(
+          `https://www.googleapis.com/calendar/v3/calendars/primary/events?singleEvents=true&orderBy=startTime&timeMin=${encodeURIComponent(
+            timeMin,
+          )}&timeMax=${encodeURIComponent(timeMax)}`,
+          {
+            headers: { Authorization: `Bearer ${token}` },
+          },
+        );
+        const data = await res.json();
+        const grouped: Record<string, any[]> = {};
+        for (const item of data.items || []) {
+          const when = item.start?.dateTime || item.start?.date;
+          if (!when) continue;
+          const key = moment(when).format('YYYY-MM-DD');
+          if (!grouped[key]) {
+            grouped[key] = [];
+          }
+          grouped[key]!.push(item);
+        }
+        setEvents(grouped);
+      } catch (err) {
+        console.error('Failed to load calendar events', err);
+        setEvents({});
+      }
+    }
+
+    fetchEvents();
+  }, [date, i18n.language]);
 
   useEffect(() => {
     setDate(date.locale(i18n.language));
@@ -148,6 +189,9 @@ function DateCalendar() {
                 onClick={() => setDate(current)}
               >
                 {Number(current.format('DD'))}
+                {events[current.format('YYYY-MM-DD')] && (
+                  <div className="calendar-event-indicator" />
+                )}
               </div>
             ) : (
               <div
@@ -166,6 +210,18 @@ function DateCalendar() {
             )
           }
         />
+        {(() => {
+          const dayEvents = events[date.format('YYYY-MM-DD')] || [];
+          return (
+            dayEvents.length > 0 && (
+              <ul className="calendar-events-list">
+                {dayEvents.map((ev) => (
+                  <li key={ev.id || ev.summary}>{ev.summary}</li>
+                ))}
+              </ul>
+            )
+          );
+        })()}
       </div>
     </BackgroundByLayersV2>
   );

--- a/src/ui/toolbar/modules/Date/Calendar.tsx
+++ b/src/ui/toolbar/modules/Date/Calendar.tsx
@@ -97,15 +97,17 @@ function DateCalendar() {
   const [token, setToken] = useState<string | null>(() =>
     localStorage.getItem('gcal_token'),
   );
+  const clientId = process.env.GCAL_CLIENT_ID;
   const tokenClientRef = useRef<any>();
   const handleAuth = () => {
-    if (!process.env.GCAL_CLIENT_ID) {
+    if (!clientId) {
+      console.warn('GCAL_CLIENT_ID is not configured');
       return;
     }
 
     const initClient = () => {
       tokenClientRef.current = window.google?.accounts?.oauth2.initTokenClient({
-        client_id: process.env.GCAL_CLIENT_ID!,
+        client_id: clientId,
         scope: 'https://www.googleapis.com/auth/calendar.readonly',
         callback: (res: any) => {
           const access = res.access_token as string;
@@ -208,9 +210,15 @@ function DateCalendar() {
     >
       {!token ? (
         <div className="calendar-auth">
-          <button className="calendar-auth-button" onClick={handleAuth}>
-            Connect Google Calendar
-          </button>
+          {clientId ? (
+            <button className="calendar-auth-button" onClick={handleAuth}>
+              Connect Google Calendar
+            </button>
+          ) : (
+            <span className="calendar-auth-missing">
+              Google Calendar unavailable
+            </span>
+          )}
         </div>
       ) : (
         <div onWheel={onWheel}>

--- a/src/ui/toolbar/modules/Date/Calendar.tsx
+++ b/src/ui/toolbar/modules/Date/Calendar.tsx
@@ -7,7 +7,7 @@ import { CalendarMode, HeaderRender } from 'antd/es/calendar/generateCalendar';
 import moment from 'moment';
 import { VNode } from 'preact';
 import momentGenerateConfig from 'rc-picker/es/generate/moment';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import './infra.css';
@@ -94,9 +94,43 @@ function DateCalendar() {
   const [date, setDate] = useState(moment().locale(i18n.language));
   const [viewMode, setViewMode] = useState<CalendarMode | undefined>('month');
   const [events, setEvents] = useState<Record<string, any[]>>({});
+  const [token, setToken] = useState<string | null>(() =>
+    localStorage.getItem('gcal_token'),
+  );
+  const tokenClientRef = useRef<any>();
 
   useEffect(() => {
-    const token = localStorage.getItem('gcal_token');
+    const onLoad = () => {
+      if (!process.env.GCAL_CLIENT_ID) {
+        return;
+      }
+      tokenClientRef.current = window.google?.accounts?.oauth2.initTokenClient({
+        client_id: process.env.GCAL_CLIENT_ID,
+        scope: 'https://www.googleapis.com/auth/calendar.readonly',
+        callback: (res: any) => {
+          const access = res.access_token as string;
+          localStorage.setItem('gcal_token', access);
+          setToken(access);
+        },
+      });
+    };
+
+    if (window.google?.accounts?.oauth2) {
+      onLoad();
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = 'https://accounts.google.com/gsi/client';
+    script.async = true;
+    script.onload = onLoad;
+    document.body.appendChild(script);
+  }, []);
+
+  const handleAuth = () => {
+    tokenClientRef.current?.requestAccessToken({ prompt: 'consent' });
+  };
+
+  useEffect(() => {
     if (!token) {
       setEvents({});
       return;
@@ -133,7 +167,7 @@ function DateCalendar() {
     }
 
     fetchEvents();
-  }, [date, i18n.language]);
+  }, [token, date, i18n.language]);
 
   useEffect(() => {
     setDate(date.locale(i18n.language));
@@ -169,60 +203,68 @@ function DateCalendar() {
       prefix="calendar"
       onContextMenu={(e) => e.stopPropagation()}
     >
-      <div onWheel={onWheel}>
-        <MomentCalendar
-          value={date}
-          onChange={setDate}
-          onPanelChange={(_, mode) => setViewMode(mode)}
-          className="calendar"
-          fullscreen={false}
-          mode={viewMode}
-          headerRender={DateCalendarHeader}
-          fullCellRender={(current, info) =>
-            info.type == 'date' ? (
-              <div
-                className={cx('calendar-cell-value', {
-                  'calendar-cell-selected': current.isSame(date, 'date'),
-                  'calendar-cell-today': current.isSame(info.today, 'date'),
-                  'calendar-cell-off-month': current.month() != date.month(),
-                })}
-                onClick={() => setDate(current)}
-              >
-                {Number(current.format('DD'))}
-                {events[current.format('YYYY-MM-DD')] && (
-                  <div className="calendar-event-indicator" />
-                )}
-              </div>
-            ) : (
-              <div
-                className={cx('calendar-cell-value', 'calendar-cell-month', {
-                  'calendar-cell-today': current
-                    .startOf('month')
-                    .isSame(info.today.startOf('month'), 'date'),
-                })}
-                onClick={() => {
-                  setDate(current);
-                  setViewMode('month');
-                }}
-              >
-                {current.format('MMMM')}
-              </div>
-            )
-          }
-        />
-        {(() => {
-          const dayEvents = events[date.format('YYYY-MM-DD')] || [];
-          return (
-            dayEvents.length > 0 && (
-              <ul className="calendar-events-list">
-                {dayEvents.map((ev) => (
-                  <li key={ev.id || ev.summary}>{ev.summary}</li>
-                ))}
-              </ul>
-            )
-          );
-        })()}
-      </div>
+      {!token ? (
+        <div className="calendar-auth">
+          <button className="calendar-auth-button" onClick={handleAuth}>
+            Connect Google Calendar
+          </button>
+        </div>
+      ) : (
+        <div onWheel={onWheel}>
+          <MomentCalendar
+            value={date}
+            onChange={setDate}
+            onPanelChange={(_, mode) => setViewMode(mode)}
+            className="calendar"
+            fullscreen={false}
+            mode={viewMode}
+            headerRender={DateCalendarHeader}
+            fullCellRender={(current, info) =>
+              info.type == 'date' ? (
+                <div
+                  className={cx('calendar-cell-value', {
+                    'calendar-cell-selected': current.isSame(date, 'date'),
+                    'calendar-cell-today': current.isSame(info.today, 'date'),
+                    'calendar-cell-off-month': current.month() != date.month(),
+                  })}
+                  onClick={() => setDate(current)}
+                >
+                  {Number(current.format('DD'))}
+                  {events[current.format('YYYY-MM-DD')] && (
+                    <div className="calendar-event-indicator" />
+                  )}
+                </div>
+              ) : (
+                <div
+                  className={cx('calendar-cell-value', 'calendar-cell-month', {
+                    'calendar-cell-today': current
+                      .startOf('month')
+                      .isSame(info.today.startOf('month'), 'date'),
+                  })}
+                  onClick={() => {
+                    setDate(current);
+                    setViewMode('month');
+                  }}
+                >
+                  {current.format('MMMM')}
+                </div>
+              )
+            }
+          />
+          {(() => {
+            const dayEvents = events[date.format('YYYY-MM-DD')] || [];
+            return (
+              dayEvents.length > 0 && (
+                <ul className="calendar-events-list">
+                  {dayEvents.map((ev) => (
+                    <li key={ev.id || ev.summary}>{ev.summary}</li>
+                  ))}
+                </ul>
+              )
+            );
+          })()}
+        </div>
+      )}
     </BackgroundByLayersV2>
   );
 }

--- a/src/ui/toolbar/modules/Date/Calendar.tsx
+++ b/src/ui/toolbar/modules/Date/Calendar.tsx
@@ -98,14 +98,14 @@ function DateCalendar() {
     localStorage.getItem('gcal_token'),
   );
   const tokenClientRef = useRef<any>();
+  const handleAuth = () => {
+    if (!process.env.GCAL_CLIENT_ID) {
+      return;
+    }
 
-  useEffect(() => {
-    const onLoad = () => {
-      if (!process.env.GCAL_CLIENT_ID) {
-        return;
-      }
+    const initClient = () => {
       tokenClientRef.current = window.google?.accounts?.oauth2.initTokenClient({
-        client_id: process.env.GCAL_CLIENT_ID,
+        client_id: process.env.GCAL_CLIENT_ID!,
         scope: 'https://www.googleapis.com/auth/calendar.readonly',
         callback: (res: any) => {
           const access = res.access_token as string;
@@ -113,21 +113,24 @@ function DateCalendar() {
           setToken(access);
         },
       });
+      tokenClientRef.current.requestAccessToken({ prompt: 'consent' });
     };
 
-    if (window.google?.accounts?.oauth2) {
-      onLoad();
+    if (tokenClientRef.current) {
+      tokenClientRef.current.requestAccessToken({ prompt: 'consent' });
       return;
     }
+
+    if (window.google?.accounts?.oauth2) {
+      initClient();
+      return;
+    }
+
     const script = document.createElement('script');
     script.src = 'https://accounts.google.com/gsi/client';
     script.async = true;
-    script.onload = onLoad;
+    script.onload = initClient;
     document.body.appendChild(script);
-  }, []);
-
-  const handleAuth = () => {
-    tokenClientRef.current?.requestAccessToken({ prompt: 'consent' });
   };
 
   useEffect(() => {

--- a/src/ui/toolbar/modules/Date/infra.css
+++ b/src/ui/toolbar/modules/Date/infra.css
@@ -23,4 +23,16 @@
     text-align: left;
     font-size: 12px;
   }
+
+  .calendar-auth {
+    display: flex;
+    justify-content: center;
+    padding: 12px;
+  }
+
+  .calendar-auth-button {
+    padding: 4px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+  }
 }

--- a/src/ui/toolbar/modules/Date/infra.css
+++ b/src/ui/toolbar/modules/Date/infra.css
@@ -34,5 +34,11 @@
     padding: 4px 8px;
     border-radius: 4px;
     cursor: pointer;
+    border: 1px solid currentColor;
+    background: transparent;
+  }
+
+  .calendar-auth-missing {
+    opacity: 0.6;
   }
 }

--- a/src/ui/toolbar/modules/Date/infra.css
+++ b/src/ui/toolbar/modules/Date/infra.css
@@ -7,4 +7,20 @@
     text-align: center;
     vertical-align: middle;
   }
+
+  .calendar-event-indicator {
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: currentColor;
+    margin: 2px auto 0;
+  }
+
+  .calendar-events-list {
+    margin-top: 8px;
+    max-height: 100px;
+    overflow-y: auto;
+    text-align: left;
+    font-size: 12px;
+  }
 }


### PR DESCRIPTION
## Summary
- fetch Google Calendar events via OAuth token and group by day
- highlight days with events and list events for the selected date

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68b846f2149c832e88def98f00b82362